### PR TITLE
增加文件系统继承的文件服务器类型，保证底层使用minio时候s3-connector的时候，file_server_type统一为s3，不…

### DIFF
--- a/dataintegration-file-management/dataintegration-file-management-provider/src/main/java/com/youngdatafan/dataintegration/file/management/config/FileServerProperties.java
+++ b/dataintegration-file-management/dataintegration-file-management-provider/src/main/java/com/youngdatafan/dataintegration/file/management/config/FileServerProperties.java
@@ -25,6 +25,9 @@ public class FileServerProperties {
     @ApiModelProperty("采用的服务器")
     private String useServer;
 
+    @ApiModelProperty("继承服务类型")
+    private String extendsFileType;
+
     /**
      * ftp服务器相关属性.
      */

--- a/dataintegration-file-management/dataintegration-file-management-provider/src/main/java/com/youngdatafan/dataintegration/file/management/controller/FileOperationApiController.java
+++ b/dataintegration-file-management/dataintegration-file-management-provider/src/main/java/com/youngdatafan/dataintegration/file/management/controller/FileOperationApiController.java
@@ -130,7 +130,7 @@ public class FileOperationApiController extends BaseController<DpPortalFileManag
         dpPortalFileManager.setUploadTime(new Date());
         dpPortalFileManager.setEffectiveDays(fileAddVO.getEffectiveDays());
         dpPortalFileManager.setLastModifiedTime(new Date());
-        dpPortalFileManager.setFileServerType(fileServerProperties.getUseServer());
+        dpPortalFileManager.setFileServerType(fileServerProperties.getExtendsFileType());
         dpPortalFileManager.setFileSize(String.valueOf(files.get(0).getSize()));
         FolderInfoDTO folderInfoDTO = this.dpPortalFileManagerService.queryOneFolder(fileAddVO.getPid());
         try {
@@ -177,7 +177,7 @@ public class FileOperationApiController extends BaseController<DpPortalFileManag
         dpPortalFileManager.setIsValid("Y");
         dpPortalFileManager.setUploadTime(new Date());
         dpPortalFileManager.setLastModifiedTime(new Date());
-        dpPortalFileManager.setFileServerType(fileServerProperties.getUseServer());
+        dpPortalFileManager.setFileServerType(fileServerProperties.getExtendsFileType());
         dpPortalFileManager.setFilePath(fileSystemManagerService.getRootPath() + userName + "/" + dpPortalFileManager.getFileName() + "/");
         dpPortalFileManagerService.insert(dpPortalFileManager);
         if (fileServerProperties.getS3().getCreateDir()) {
@@ -297,7 +297,7 @@ public class FileOperationApiController extends BaseController<DpPortalFileManag
         dpPortalFileManager1.setUploadTime(new Date());
         dpPortalFileManager1.setLastModifiedTime(new Date());
         dpPortalFileManager1.setIsFolder(dpPortalFileManager.getIsFolder());
-        dpPortalFileManager1.setFileServerType(fileServerProperties.getUseServer());
+        dpPortalFileManager1.setFileServerType(fileServerProperties.getExtendsFileType());
         dpPortalFileManagerService.updateByPrimaryKeySelective(dpPortalFileManager1);
         DpPortalFileManagerDTO dpPortalFileManagerDTO = new DpPortalFileManagerDTO();
         BeanUtils.copyProperties(dpPortalFileManager1, dpPortalFileManagerDTO);
@@ -318,7 +318,7 @@ public class FileOperationApiController extends BaseController<DpPortalFileManag
         dpPortalFileManager1.setIsValid(fileUpdateVO.getIsValid());
         dpPortalFileManager1.setLastModifiedTime(new Date());
         dpPortalFileManager1.setIsFolder("1");
-        dpPortalFileManager1.setFileServerType(fileServerProperties.getUseServer());
+        dpPortalFileManager1.setFileServerType(fileServerProperties.getExtendsFileType());
         dpPortalFileManagerService.updateByPrimaryKeySelective(dpPortalFileManager1);
         DpPortalFileManagerDTO dpPortalFileManagerDTO = new DpPortalFileManagerDTO();
         BeanUtils.copyProperties(dpPortalFileManager1, dpPortalFileManagerDTO);
@@ -653,7 +653,7 @@ public class FileOperationApiController extends BaseController<DpPortalFileManag
                     dpPortalFileManagerNew.setIsValid("Y");
                     dpPortalFileManagerNew.setUploadTime(objectSummary.getLastModified());
                     dpPortalFileManagerNew.setLastModifiedTime(objectSummary.getLastModified());
-                    dpPortalFileManagerNew.setFileServerType(fileServerProperties.getUseServer());
+                    dpPortalFileManagerNew.setFileServerType(fileServerProperties.getExtendsFileType());
                     dpPortalFileManagerNew.setFileSize(String.valueOf(objectSummary.getSize()));
                     dpPortalFileManagerNew.setFilePath(dpPortalFileManager.getFilePath() + dpPortalFileManagerNew.getFileName());
                     metaInsterLists.add(dpPortalFileManagerNew);
@@ -859,7 +859,7 @@ public class FileOperationApiController extends BaseController<DpPortalFileManag
                     dpPortalFileManager.setUploadTime(new Date());
                     dpPortalFileManager.setLastModifiedTime(new Date());
                     dpPortalFileManager.setFilePath(path);
-                    dpPortalFileManager.setFileServerType(fileServerProperties.getUseServer());
+                    dpPortalFileManager.setFileServerType(fileServerProperties.getExtendsFileType());
                     dpPortalFileManager.setFileSize(String.valueOf(file.getSize()));
                     dpPortalFileManagerService.insert(dpPortalFileManager);
 
@@ -978,7 +978,7 @@ public class FileOperationApiController extends BaseController<DpPortalFileManag
         dpPortalFileManager.setEffectiveDays(effectiveDays);
         dpPortalFileManager.setUploadTime(new Date());
         dpPortalFileManager.setLastModifiedTime(new Date());
-        dpPortalFileManager.setFileServerType(fileServerProperties.getUseServer());
+        dpPortalFileManager.setFileServerType(fileServerProperties.getExtendsFileType());
         dpPortalFileManager.setFileSize(String.valueOf(file.getSize()));
         DpPortalFileManager dpPortalFileManager1 = dpPortalFileManagerService.selectByFileId(pid);
         try {

--- a/dataintegration-file-management/dataintegration-file-management-provider/src/main/java/com/youngdatafan/dataintegration/file/management/controller/FileOperationToModelApiController.java
+++ b/dataintegration-file-management/dataintegration-file-management-provider/src/main/java/com/youngdatafan/dataintegration/file/management/controller/FileOperationToModelApiController.java
@@ -81,7 +81,7 @@ public class FileOperationToModelApiController extends BaseController<DpPortalFi
         dpPortalFileManager.setPid("ai_model");
         dpPortalFileManager.setUploadTime(new Date());
         dpPortalFileManager.setCreateChannel("AIMODEL");
-        dpPortalFileManager.setFileServerType(fileServerProperties.getUseServer());
+        dpPortalFileManager.setFileServerType(fileServerProperties.getExtendsFileType());
         dpPortalFileManager.setFilePath(fileSystemManagerService.getRootPath() + userName + "/ai_model/" + dpPortalFileManager.getFileName());
         try {
             fileSystemManagerService.addFile(dpPortalFileManager.getFilePath(), file.getInputStream(), file.getSize());

--- a/dataintegration-file-management/dataintegration-file-management-provider/src/main/java/com/youngdatafan/dataintegration/file/management/service/impl/DpPortalFileManagerServiceImpl.java
+++ b/dataintegration-file-management/dataintegration-file-management-provider/src/main/java/com/youngdatafan/dataintegration/file/management/service/impl/DpPortalFileManagerServiceImpl.java
@@ -340,7 +340,7 @@ public class DpPortalFileManagerServiceImpl implements DpPortalFileManagerServic
                 dpPortalFileManagerNew.setIsValid("Y");
                 dpPortalFileManagerNew.setUploadTime(objectSummary.getLastModified());
                 dpPortalFileManagerNew.setLastModifiedTime(objectSummary.getLastModified());
-                dpPortalFileManagerNew.setFileServerType(fileServerProperties.getUseServer());
+                dpPortalFileManagerNew.setFileServerType(fileServerProperties.getExtendsFileType());
                 dpPortalFileManagerNew.setFileSize(String.valueOf(objectSummary.getSize()));
                 dpPortalFileManagerNew.setFilePath(folderInfoDTO.getFilePath() + dpPortalFileManagerNew.getFileName());
                 metaInsterLists.add(dpPortalFileManagerNew);

--- a/dataintegration-file-management/dataintegration-file-management-provider/src/main/java/com/youngdatafan/dataintegration/file/management/service/impl/MinIoFileSystemManagerServiceImpl.java
+++ b/dataintegration-file-management/dataintegration-file-management-provider/src/main/java/com/youngdatafan/dataintegration/file/management/service/impl/MinIoFileSystemManagerServiceImpl.java
@@ -19,7 +19,6 @@ import io.minio.StatObjectArgs;
 import io.minio.StatObjectResponse;
 import io.minio.messages.Item;
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.InputStream;
 import java.sql.Timestamp;
 import java.time.ZonedDateTime;
@@ -127,7 +126,7 @@ public class MinIoFileSystemManagerServiceImpl implements FileSystemManagerServi
 
     @Override
     public void addFolder(String parentFolder) throws DpException {
-        String lastFolder = parentFolder + File.separator;
+        String lastFolder = parentFolder + "/";
         try {
             minioClient.putObject(
                 PutObjectArgs.builder().bucket(minIoProperties.getBucketName()).object(lastFolder).stream(

--- a/dataintegration-file-management/dataintegration-file-management-provider/src/main/resources/application-local.yaml
+++ b/dataintegration-file-management/dataintegration-file-management-provider/src/main/resources/application-local.yaml
@@ -70,7 +70,8 @@ pagehelper:
 #文件存储类型
 file:
   server:
-    useServer: s3
+    useServer: minio
+    extendsFileType: s3
     ftp:
       server: 192.168.124.166
       port: 20021

--- a/dataintegration-file-management/dataintegration-file-management-provider/src/main/resources/application-test.yaml
+++ b/dataintegration-file-management/dataintegration-file-management-provider/src/main/resources/application-test.yaml
@@ -68,7 +68,8 @@ pagehelper:
 #文件存储类型
 file:
   server:
-    useServer: s3
+    useServer: minio
+    extendsFileType: s3
     ftp:
       server: 192.168.124.166
       port: 20021


### PR DESCRIPTION
…会出现错误提示文件类型不支持

<!--Thanks very much for contributing to Data Integration.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dataintegration-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
